### PR TITLE
Implement the manhattan distance calculation method

### DIFF
--- a/clustering/KmeansClusterer.py
+++ b/clustering/KmeansClusterer.py
@@ -1,9 +1,10 @@
 import numpy as np
 from tqdm import tqdm
+from clustering.distance import distance_calculation_methods
 
 
 class KmeansClusterer:
-    def __init__(self, k, dataset):
+    def __init__(self, k, dataset, distance="euclidian"):
         dataset_dimensions = dataset.shape
         self.number_of_clusters = k
         self.clusters = [[] for i in range(self.number_of_clusters)]
@@ -12,6 +13,10 @@ class KmeansClusterer:
         random_points_indexes = np.random.choice(
             np.arange(dataset_dimensions[0]), k, replace=False
         )
+        try:
+            self.distance_calculation_method = distance_calculation_methods[distance.lower()]
+        except KeyError:
+            raise Exception("Invalid distance method: {}".format(distance))
         for i, rand in enumerate(random_points_indexes):
             self.centroids[i] = self.dataset[rand]
 
@@ -19,9 +24,9 @@ class KmeansClusterer:
         self.clusters = [[] for i in range(self.number_of_clusters)]
         for d in self.dataset:
             closest_centroid_index = 0
-            smallest_distance = np.sqrt(np.sum(np.power(self.centroids[0] - d, 2)))
+            smallest_distance = self._calculate_distance(self.centroids[0], d)
             for i, centroid in enumerate(self.centroids):
-                distance = np.sqrt(np.sum(np.power(centroid - d, 2)))
+                distance = self._calculate_distance(centroid, d)
                 if distance < smallest_distance:
                     smallest_distance = distance
                     closest_centroid_index = i
@@ -31,14 +36,14 @@ class KmeansClusterer:
         for i, cluster in enumerate(self.clusters):
             self.centroids[i] = sum(cluster) / len(cluster)
 
+    def _calculate_distance(self, p1, p2):
+        return self.distance_calculation_method(p1, p2)
 
     def run(self, number_of_iterations):
-        for i in tqdm(range(number_of_iterations)):
+        for _ in tqdm(range(number_of_iterations)):
             self._assign_data_to_clusters()
             self._update_centroids()
-        
         result = []
         for cluster in self.clusters:
             result.append(np.array(cluster).T)
-        
         return result

--- a/clustering/distance.py
+++ b/clustering/distance.py
@@ -1,0 +1,6 @@
+import numpy as np
+
+distance_calculation_methods = {
+    "euclidian": lambda p1, p2: np.sqrt(np.sum(np.power(p1 - p2, 2))),
+    "manhattan": lambda p1, p2: np.sum(np.absolute(p1 - p2)),
+}

--- a/main.py
+++ b/main.py
@@ -8,19 +8,18 @@ def generate_random_points(number_of_points, dimension):
     points = np.random.rand(number_of_points, dimension)
     return points
 
-if __name__ == '__main__':
-    points = generate_random_points(5000, 3)
-    clusterer = KmeansClusterer(5, points)
+
+if __name__ == "__main__":
+    points = generate_random_points(2000, 3)
+    clusterer = KmeansClusterer(5, points, distance="manhattan")
     clusters = clusterer.run(10)
     fig = plt.figure()
-    ax = fig.add_subplot(111, projection='3d')
+    ax = fig.add_subplot(111, projection="3d")
     for cluster in clusters:
         ax.scatter(cluster[0], cluster[1], cluster[2])
-    
-    ax.set_xlabel('X Label')
-    ax.set_ylabel('Y Label')
-    ax.set_zlabel('Z Label')
+
+    ax.set_xlabel("X Label")
+    ax.set_ylabel("Y Label")
+    ax.set_zlabel("Z Label")
     plt.title("3D K-means Clustering")
     plt.show()
-        
-    


### PR DESCRIPTION
Implements the manhattan distance calculation method to be used when assigning dataset instances to different clusters during the execution of the algorithm.﻿
